### PR TITLE
Refactor backend context and session helpers

### DIFF
--- a/routes/dashboard.js
+++ b/routes/dashboard.js
@@ -2,10 +2,18 @@
  * GET supervisord page
  */
 
-export function dashboard() {
+import { ensureAuthenticatedRequest } from '../server/session.js';
+
+/** @typedef {import('../server/types.js').ServerContext} ServerContext */
+
+/**
+ * @param {ServerContext} _context
+ * @returns {import('../server/types.js').RequestHandler}
+ */
+export function dashboard(_context) {
   return function (req, res) {
-    if (!req.session.loggedIn) {
-      return res.redirect('/login');
+    if (!ensureAuthenticatedRequest(req, res)) {
+      return;
     }
 
     return res.render('dashboard', {

--- a/routes/groups.js
+++ b/routes/groups.js
@@ -2,14 +2,19 @@
  * GET/POST groups page
  */
 
-export function groups(params) {
-  const { db, config } = params;
+import { ensureAdminRequest } from '../server/session.js';
+
+/** @typedef {import('../server/types.js').ServerContext} ServerContext */
+
+/**
+ * @param {ServerContext} context
+ * @returns {import('../server/types.js').RequestHandler}
+ */
+export function groups(context) {
+  const { db, config } = context;
   return async function (req, res, next) {
-    if (!req.session.loggedIn) {
-      return res.redirect('/login');
-    }
-    if (req.session.user.Role !== 'Admin') {
-      return res.redirect('/dashboard');
+    if (!ensureAdminRequest(req, res)) {
+      return;
     }
 
     try {

--- a/routes/hosts.js
+++ b/routes/hosts.js
@@ -2,14 +2,19 @@
  * GET/POST hosts page
  */
 
-export function hosts(params) {
-  const { db, config } = params;
+import { ensureAdminRequest } from '../server/session.js';
+
+/** @typedef {import('../server/types.js').ServerContext} ServerContext */
+
+/**
+ * @param {ServerContext} context
+ * @returns {import('../server/types.js').RequestHandler}
+ */
+export function hosts(context) {
+  const { db, config } = context;
   return async function (req, res, next) {
-    if (!req.session.loggedIn) {
-      return res.redirect('/login');
-    }
-    if (req.session.user.Role !== 'Admin') {
-      return res.redirect('/dashboard');
+    if (!ensureAdminRequest(req, res)) {
+      return;
     }
 
     try {

--- a/routes/log.js
+++ b/routes/log.js
@@ -2,15 +2,19 @@
  * GET log page
  */
 
-export function log(params) {
-  const { config } = params;
-  return function (req, res) {
-    if (!req.session.loggedIn) {
-      return res.redirect('/login');
-    }
+import { ensureAdminRequest } from '../server/session.js';
 
-    if (req.session.user.Role !== 'Admin') {
-      return res.redirect('/dashboard');
+/** @typedef {import('../server/types.js').ServerContext} ServerContext */
+
+/**
+ * @param {ServerContext} context
+ * @returns {import('../server/types.js').RequestHandler}
+ */
+export function log(context) {
+  const { config } = context;
+  return function (req, res) {
+    if (!ensureAdminRequest(req, res)) {
+      return;
     }
 
     if (req.params.host && req.params.process) {

--- a/routes/logout.js
+++ b/routes/logout.js
@@ -2,7 +2,13 @@
  * GET logout page
  */
 
-export function logout() {
+/** @typedef {import('../server/types.js').ServerContext} ServerContext */
+
+/**
+ * @param {ServerContext} _context
+ * @returns {import('../server/types.js').RequestHandler}
+ */
+export function logout(_context) {
   return function (req, res, next) {
     req.session.destroy(function (err) {
       if (err) {

--- a/routes/supervisord.js
+++ b/routes/supervisord.js
@@ -2,14 +2,18 @@
  * GET supervisord page
  */
 
-export function supervisord() {
-  return function (req, res) {
-    if (!req.session.loggedIn) {
-      return res.redirect('/login');
-    }
+import { ensureAdminRequest } from '../server/session.js';
 
-    if (req.session.user.Role !== 'Admin') {
-      return res.redirect('/dashboard');
+/** @typedef {import('../server/types.js').ServerContext} ServerContext */
+
+/**
+ * @param {ServerContext} _context
+ * @returns {import('../server/types.js').RequestHandler}
+ */
+export function supervisord(_context) {
+  return function (req, res) {
+    if (!ensureAdminRequest(req, res)) {
+      return;
     }
 
     return res.render('supervisord', {

--- a/routes/users.js
+++ b/routes/users.js
@@ -4,15 +4,19 @@
 
 import bcrypt from 'bcrypt';
 
-export function users(params) {
-  const { db } = params;
-  return async function (req, res, next) {
-    if (!req.session.loggedIn) {
-      return res.redirect('/login');
-    }
+import { ensureAdminRequest } from '../server/session.js';
 
-    if (req.session.user.Role !== 'Admin') {
-      return res.redirect('/dashboard');
+/** @typedef {import('../server/types.js').ServerContext} ServerContext */
+
+/**
+ * @param {ServerContext} context
+ * @returns {import('../server/types.js').RequestHandler}
+ */
+export function users(context) {
+  const { db } = context;
+  return async function (req, res, next) {
+    if (!ensureAdminRequest(req, res)) {
+      return;
     }
 
     try {

--- a/server/app.js
+++ b/server/app.js
@@ -12,11 +12,21 @@ import { fileURLToPath } from 'url';
 
 import { createRouter } from '../routes/index.js';
 
+/** @typedef {import('./types.js').ServerContext} ServerContext */
+
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 const projectRoot = path.resolve(__dirname, '..');
 
-export function createApp({ config, db, supervisordapi, sessionStore }) {
+/**
+ * Constructs the primary Express application using the provided server
+ * context. The context keeps configuration, database connections and other
+ * shared services consistent across the backend modules.
+ *
+ * @param {ServerContext} context
+ */
+export function createApp(context) {
+  const { config, db, supervisordapi, sessionStore } = context;
   const app = express();
 
   app.set('port', config.port);
@@ -49,7 +59,7 @@ export function createApp({ config, db, supervisordapi, sessionStore }) {
     app.use(errorhandler());
   }
 
-  const router = createRouter({ app, config, db, supervisordapi });
+  const router = createRouter(context);
   app.use(router);
 
   return app;

--- a/server/context.js
+++ b/server/context.js
@@ -1,0 +1,33 @@
+import { createRequire } from 'module';
+
+/** @typedef {import('./types.js').ServerContext} ServerContext */
+/** @typedef {import('./types.js').ServerConfig} ServerConfig */
+/** @typedef {import('./types.js').Knex} Knex */
+/** @typedef {import('./types.js').SessionStore} SessionStore */
+
+const require = createRequire(import.meta.url);
+const packageJson = require('../package.json');
+
+/**
+ * Creates an immutable context object used by the server and route layers.
+ *
+ * @param {Object} params
+ * @param {ServerConfig} params.config
+ * @param {Knex} params.db
+ * @param {SessionStore} params.sessionStore
+ * @param {typeof import('supervisord')} params.supervisordapi
+ * @returns {ServerContext}
+ */
+export function createServerContext({ config, db, sessionStore, supervisordapi }) {
+  if (!config || !db || !sessionStore || !supervisordapi) {
+    throw new Error('Invalid server context configuration');
+  }
+
+  return Object.freeze({
+    config,
+    db,
+    sessionStore,
+    supervisordapi,
+    version: packageJson.version
+  });
+}

--- a/server/index.js
+++ b/server/index.js
@@ -4,6 +4,7 @@ import supervisordapi from 'supervisord';
 
 import config from '../config.js';
 import { createApp } from './app.js';
+import { createServerContext } from './context.js';
 
 const db = Knex(config.db);
 const knexsessions = Knex(config.sessionstore);
@@ -14,11 +15,18 @@ const sessionStore = new ConnectSessionKnexStore({
   createTable: true
 });
 
-const app = createApp({ config, db, supervisordapi, sessionStore });
+const context = createServerContext({
+  config,
+  db,
+  supervisordapi,
+  sessionStore
+});
+
+const app = createApp(context);
 
 async function start() {
   try {
-    await config.readHosts(db);
+    await context.config.readHosts(context.db);
     app.listen(app.get('port'), app.get('host'), () => {
       console.log(`Nodervisor launched on ${app.get('host')}:${app.get('port')}`);
     });

--- a/server/session.js
+++ b/server/session.js
@@ -1,0 +1,111 @@
+import { ServiceError } from '../services/supervisordService.js';
+
+/** @typedef {import('./types.js').RequestSession} RequestSession */
+/** @typedef {import('./types.js').UserRow} UserRow */
+/** @typedef {import('express').Request} Request */
+/** @typedef {import('express').Response} Response */
+
+/**
+ * Returns the authenticated user attached to the session.
+ *
+ * @param {RequestSession | undefined | null} session
+ * @returns {UserRow | null}
+ */
+export function getSessionUser(session) {
+  return session?.user ?? null;
+}
+
+/**
+ * Determines whether the provided session represents an authenticated user.
+ *
+ * @param {RequestSession | undefined | null} session
+ * @returns {session is RequestSession & { loggedIn: true; user: UserRow }}
+ */
+export function isSessionAuthenticated(session) {
+  return Boolean(session?.loggedIn && session?.user);
+}
+
+/**
+ * Determines whether the session user has the Administrator role.
+ *
+ * @param {RequestSession | undefined | null} session
+ * @returns {boolean}
+ */
+export function isSessionAdmin(session) {
+  return isSessionAuthenticated(session) && getSessionUser(session)?.Role === 'Admin';
+}
+
+/**
+ * Ensures the current request is authenticated. Returns true when the caller
+ * should proceed, false when a redirect response has already been sent.
+ *
+ * @param {Request & { session?: RequestSession }} req
+ * @param {Response} res
+ * @param {string} [redirectTo='/login']
+ * @returns {boolean}
+ */
+export function ensureAuthenticatedRequest(req, res, redirectTo = '/login') {
+  if (!isSessionAuthenticated(req.session)) {
+    res.redirect(redirectTo);
+    return false;
+  }
+
+  return true;
+}
+
+/**
+ * Ensures the current request belongs to an authenticated administrator. The
+ * return value mirrors {@link ensureAuthenticatedRequest}.
+ *
+ * @param {Request & { session?: RequestSession }} req
+ * @param {Response} res
+ * @param {string} [redirectTo='/dashboard']
+ * @returns {boolean}
+ */
+export function ensureAdminRequest(req, res, redirectTo = '/dashboard') {
+  if (!ensureAuthenticatedRequest(req, res)) {
+    return false;
+  }
+
+  if (!isSessionAdmin(req.session)) {
+    res.redirect(redirectTo);
+    return false;
+  }
+
+  return true;
+}
+
+/**
+ * Asserts that a session is authenticated, throwing a {@link ServiceError}
+ * when it is not. This is primarily useful for JSON API handlers where
+ * redirects are undesirable.
+ *
+ * @param {RequestSession | undefined | null} session
+ * @returns {RequestSession & { loggedIn: true; user: UserRow }}
+ * @throws {ServiceError}
+ */
+export function assertSessionAuthenticated(session) {
+  if (!isSessionAuthenticated(session)) {
+    throw new ServiceError('Not authenticated', 401);
+  }
+
+  return session;
+}
+
+/**
+ * Asserts that the current session user is an administrator. Throws a
+ * {@link ServiceError} when the requirement is not satisfied.
+ *
+ * @param {RequestSession | undefined | null} session
+ * @returns {RequestSession & { loggedIn: true; user: UserRow }}
+ * @throws {ServiceError}
+ */
+export function assertSessionAdmin(session) {
+  const authenticatedSession = assertSessionAuthenticated(session);
+
+  if (!isSessionAdmin(authenticatedSession)) {
+    throw new ServiceError('Insufficient privileges', 403);
+  }
+
+  return authenticatedSession;
+}

--- a/server/types.js
+++ b/server/types.js
@@ -1,0 +1,95 @@
+/**
+ * Shared type definitions for the Nodervisor backend.
+ * These typedef exports allow other modules to consume runtime code
+ * while still benefitting from rich editor hints via JSDoc.
+ */
+
+/** @typedef {import('knex').Knex} Knex */
+/** @typedef {import('express').Request} ExpressRequest */
+/** @typedef {import('express').Response} ExpressResponse */
+/** @typedef {import('express').NextFunction} ExpressNext */
+/** @typedef {import('express-session').Store} SessionStore */
+
+/**
+ * @typedef {Object} GroupRow
+ * @property {number} idGroup
+ * @property {string} Name
+ */
+export let GroupRow;
+
+/**
+ * @typedef {Object} HostRow
+ * @property {number} idHost
+ * @property {string} Name
+ * @property {string} Url
+ * @property {number|null} [idGroup]
+ * @property {string|null} [GroupName]
+ */
+export let HostRow;
+
+/**
+ * @typedef {Object} UserRow
+ * @property {number} id
+ * @property {string} Name
+ * @property {string} Email
+ * @property {string} Password
+ * @property {string} Role
+ */
+export let UserRow;
+
+/**
+ * @typedef {import('express-session').Session & import('express-session').SessionData & {
+ *   loggedIn?: boolean;
+ *   user?: UserRow | null;
+ * }} RequestSession
+ */
+export let RequestSession;
+
+/**
+ * @typedef {Object<string|number, HostRow>} HostRegistry
+ */
+export let HostRegistry;
+
+/**
+ * @typedef {Object} ServerConfig
+ * @property {import('knex').Knex.Config} db
+ * @property {import('knex').Knex.Config} sessionstore
+ * @property {number|string} port
+ * @property {string} host
+ * @property {string} env
+ * @property {string} sessionSecret
+ * @property {HostRegistry} hosts
+ * @property {(db: Knex) => Promise<HostRegistry>} readHosts
+ */
+export let ServerConfig;
+
+/**
+ * @typedef {Object} ServerContext
+ * @property {ServerConfig} config
+ * @property {Knex} db
+ * @property {SessionStore} sessionStore
+ * @property {typeof import('supervisord')} supervisordapi
+ * @property {string} [version]
+ */
+export let ServerContext;
+
+/**
+ * @typedef {import('express').RequestHandler} RequestHandler
+ */
+export let RequestHandler;
+
+/**
+ * @typedef {(
+ *   context: ServerContext
+ * ) => RequestHandler} RouteFactory
+ */
+export let RouteFactory;
+
+/**
+ * @typedef {(
+ *   req: ExpressRequest & { session?: RequestSession },
+ *   res: ExpressResponse,
+ *   next: ExpressNext
+ * ) => void | Promise<void>} RouteMiddleware
+ */
+export let RouteMiddleware;


### PR DESCRIPTION
## Summary
- add shared server context and typed helper modules for config, database rows, and request sessions
- refactor the Express app bootstrap and router wiring to consume the centralized context abstractions
- update route handlers to use reusable session guards with JSDoc typing for improved consistency

## Testing
- npm run build:dashboard *(fails: vite binary unavailable in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d55c51dee0832e926d057d6638fdc7