### PR TITLE
Refactor routes to use repository layer

### DIFF
--- a/__tests__/data/groups.test.js
+++ b/__tests__/data/groups.test.js
@@ -1,0 +1,64 @@
+import knex from 'knex';
+import { afterAll, beforeAll, beforeEach, describe, expect, it } from '@jest/globals';
+
+import { createGroupsRepository } from '../../data/groups.js';
+
+let db;
+let groupsRepository;
+
+beforeAll(async () => {
+  db = knex({
+    client: 'sqlite3',
+    connection: { filename: ':memory:' },
+    useNullAsDefault: true
+  });
+
+  await db.schema.createTable('groups', (table) => {
+    table.increments('idGroup').primary();
+    table.string('Name');
+  });
+});
+
+beforeEach(async () => {
+  await db('groups').del();
+  groupsRepository = createGroupsRepository(db);
+});
+
+afterAll(async () => {
+  await db.destroy();
+});
+
+describe('groups repository', () => {
+  it('creates groups with normalized casing', async () => {
+    const group = await groupsRepository.createGroup({ name: 'Operators' });
+
+    expect(group).toEqual({ id: expect.any(Number), name: 'Operators' });
+
+    const stored = await db('groups').first();
+    expect(stored.Name).toBe('Operators');
+  });
+
+  it('updates group names within a transaction', async () => {
+    const group = await groupsRepository.createGroup({ name: 'Build' });
+
+    const updated = await groupsRepository.updateGroup(group.id, { name: 'Build & Deploy' });
+    expect(updated).toEqual({ id: group.id, name: 'Build & Deploy' });
+
+    const reloaded = await groupsRepository.getGroupById(group.id);
+    expect(reloaded).toEqual(updated);
+  });
+
+  it('lists and deletes groups', async () => {
+    const first = await groupsRepository.createGroup({ name: 'Alpha' });
+    const second = await groupsRepository.createGroup({ name: 'Beta' });
+
+    const groups = await groupsRepository.listGroups();
+    expect(groups).toEqual([first, second]);
+
+    const deleted = await groupsRepository.deleteGroup(first.id);
+    expect(deleted).toBe(1);
+
+    const remaining = await groupsRepository.listGroups();
+    expect(remaining).toEqual([second]);
+  });
+});

--- a/__tests__/data/hosts.test.js
+++ b/__tests__/data/hosts.test.js
@@ -1,0 +1,104 @@
+import knex from 'knex';
+import { afterAll, beforeAll, beforeEach, describe, expect, it } from '@jest/globals';
+
+import { createHostsRepository } from '../../data/hosts.js';
+
+let db;
+let hostsRepository;
+
+beforeAll(async () => {
+  db = knex({
+    client: 'sqlite3',
+    connection: { filename: ':memory:' },
+    useNullAsDefault: true
+  });
+
+  await db.schema.createTable('groups', (table) => {
+    table.increments('idGroup').primary();
+    table.string('Name');
+  });
+
+  await db.schema.createTable('hosts', (table) => {
+    table.increments('idHost').primary();
+    table.integer('idGroup').references('idGroup').inTable('groups').onDelete('SET NULL');
+    table.string('Name');
+    table.string('Url');
+  });
+});
+
+beforeEach(async () => {
+  await db('hosts').del();
+  await db('groups').del();
+  hostsRepository = createHostsRepository(db);
+});
+
+afterAll(async () => {
+  await db.destroy();
+});
+
+describe('hosts repository', () => {
+  it('creates hosts and returns normalized records', async () => {
+    const [groupId] = await db('groups').insert({ Name: 'Web Servers' });
+
+    const host = await hostsRepository.createHost({
+      name: 'frontend',
+      url: 'http://frontend:9001',
+      groupId
+    });
+
+    expect(host).toEqual({
+      id: expect.any(Number),
+      name: 'frontend',
+      url: 'http://frontend:9001',
+      groupId,
+      groupName: 'Web Servers'
+    });
+
+    const stored = await db('hosts').first();
+    expect(stored.Name).toBe('frontend');
+    expect(stored.Url).toBe('http://frontend:9001');
+    expect(stored.idGroup).toBe(groupId);
+  });
+
+  it('updates hosts inside a transaction and preserves relationships', async () => {
+    const [groupId] = await db('groups').insert({ Name: 'API' });
+    const [otherGroupId] = await db('groups').insert({ Name: 'Batch' });
+
+    const host = await hostsRepository.createHost({
+      name: 'api-1',
+      url: 'http://api-1:9001',
+      groupId
+    });
+
+    const updated = await hostsRepository.updateHost(host.id, {
+      name: 'api-2',
+      url: 'http://api-2:9001',
+      groupId: otherGroupId
+    });
+
+    expect(updated).toEqual({
+      id: host.id,
+      name: 'api-2',
+      url: 'http://api-2:9001',
+      groupId: otherGroupId,
+      groupName: 'Batch'
+    });
+
+    const reloaded = await hostsRepository.getHostById(host.id);
+    expect(reloaded).toEqual(updated);
+  });
+
+  it('deletes hosts and returns the affected row count', async () => {
+    const host = await hostsRepository.createHost({
+      name: 'orphan',
+      url: 'http://orphan:9001',
+      groupId: null
+    });
+
+    const deleted = await hostsRepository.deleteHost(host.id);
+    expect(deleted).toBe(1);
+
+    const hosts = await hostsRepository.listHosts();
+    expect(hosts).toEqual([]);
+  });
+});

--- a/__tests__/data/users.test.js
+++ b/__tests__/data/users.test.js
@@ -1,0 +1,130 @@
+import knex from 'knex';
+import { afterAll, beforeAll, beforeEach, describe, expect, it } from '@jest/globals';
+
+import { createUsersRepository } from '../../data/users.js';
+
+let db;
+let usersRepository;
+
+beforeAll(async () => {
+  db = knex({
+    client: 'sqlite3',
+    connection: { filename: ':memory:' },
+    useNullAsDefault: true
+  });
+
+  await db.schema.createTable('users', (table) => {
+    table.increments('id').primary();
+    table.string('Name');
+    table.string('Email');
+    table.string('Password');
+    table.string('Role');
+  });
+});
+
+beforeEach(async () => {
+  await db('users').del();
+  usersRepository = createUsersRepository(db);
+});
+
+afterAll(async () => {
+  await db.destroy();
+});
+
+describe('users repository', () => {
+  it('creates users with hashed passwords and normalized casing', async () => {
+    const user = await usersRepository.createUser({
+      name: 'Ada Lovelace',
+      email: 'ada@example.com',
+      passwordHash: 'hashed',
+      role: 'Admin'
+    });
+
+    expect(user).toEqual({
+      id: expect.any(Number),
+      name: 'Ada Lovelace',
+      email: 'ada@example.com',
+      role: 'Admin'
+    });
+
+    const stored = await db('users').first();
+    expect(stored.Password).toBe('hashed');
+  });
+
+  it('finds users by email including password hashes', async () => {
+    await usersRepository.createUser({
+      name: 'Grace Hopper',
+      email: 'grace@example.com',
+      passwordHash: 'hashed-password',
+      role: 'User'
+    });
+
+    const user = await usersRepository.findByEmail('grace@example.com');
+    expect(user).toEqual({
+      id: expect.any(Number),
+      name: 'Grace Hopper',
+      email: 'grace@example.com',
+      role: 'User',
+      passwordHash: 'hashed-password'
+    });
+  });
+
+  it('updates users and preserves password when not provided', async () => {
+    const user = await usersRepository.createUser({
+      name: 'Linus Torvalds',
+      email: 'linus@example.com',
+      passwordHash: 'initial',
+      role: 'User'
+    });
+
+    const updated = await usersRepository.updateUser(user.id, {
+      name: 'Linus',
+      email: 'linus@example.com',
+      role: 'Admin'
+    });
+
+    expect(updated).toEqual({
+      id: user.id,
+      name: 'Linus',
+      email: 'linus@example.com',
+      role: 'Admin'
+    });
+
+    const stored = await db('users').where('id', user.id).first();
+    expect(stored.Password).toBe('initial');
+  });
+
+  it('updates the password hash when provided', async () => {
+    const user = await usersRepository.createUser({
+      name: 'Margaret Hamilton',
+      email: 'margaret@example.com',
+      passwordHash: 'before',
+      role: 'Admin'
+    });
+
+    await usersRepository.updateUser(user.id, {
+      name: 'Margaret Hamilton',
+      email: 'margaret@example.com',
+      role: 'Admin',
+      passwordHash: 'after'
+    });
+
+    const stored = await db('users').where('id', user.id).first();
+    expect(stored.Password).toBe('after');
+  });
+
+  it('deletes users', async () => {
+    const user = await usersRepository.createUser({
+      name: 'Barbara Liskov',
+      email: 'barbara@example.com',
+      passwordHash: 'secret',
+      role: 'User'
+    });
+
+    const deleted = await usersRepository.deleteUser(user.id);
+    expect(deleted).toBe(1);
+
+    const users = await usersRepository.listUsers();
+    expect(users).toEqual([]);
+  });
+});

--- a/data/groups.js
+++ b/data/groups.js
@@ -1,0 +1,96 @@
+import { resolveInsertedId } from './utils.js';
+
+/** @typedef {import('../server/types.js').Knex} Knex */
+/** @typedef {import('../server/types.js').Group} Group */
+
+/**
+ * Creates a repository responsible for group persistence.
+ *
+ * @param {Knex} db
+ */
+export function createGroupsRepository(db) {
+  const TABLE = 'groups';
+  const ID_COLUMN = 'idGroup';
+
+  /**
+   * @param {any} row
+   * @returns {Group | null}
+   */
+  function mapGroup(row) {
+    if (!row) {
+      return null;
+    }
+
+    return {
+      id: row.idGroup,
+      name: row.Name
+    };
+  }
+
+  return {
+    /**
+     * Retrieves all groups.
+     *
+     * @returns {Promise<Group[]>}
+     */
+    async listGroups() {
+      const rows = await db(TABLE).select('idGroup', 'Name').orderBy(ID_COLUMN);
+      return rows.map((row) => mapGroup(row)).filter(Boolean);
+    },
+
+    /**
+     * Retrieves a group by its identifier.
+     *
+     * @param {number} id
+     * @returns {Promise<Group | null>}
+     */
+    async getGroupById(id) {
+      const row = await db(TABLE).where(ID_COLUMN, id).first();
+      return mapGroup(row);
+    },
+
+    /**
+     * Creates a new group.
+     *
+     * @param {{ name: string }} input
+     * @returns {Promise<Group | null>}
+     */
+    async createGroup({ name }) {
+      return db.transaction(async (trx) => {
+        const insertResult = await trx(TABLE).insert({ Name: name });
+        const id = await resolveInsertedId(trx, TABLE, ID_COLUMN, insertResult);
+        if (id == null) {
+          return null;
+        }
+
+        const row = await trx(TABLE).where(ID_COLUMN, id).first();
+        return mapGroup(row);
+      });
+    },
+
+    /**
+     * Updates an existing group.
+     *
+     * @param {number} id
+     * @param {{ name: string }} input
+     * @returns {Promise<Group | null>}
+     */
+    async updateGroup(id, { name }) {
+      return db.transaction(async (trx) => {
+        await trx(TABLE).where(ID_COLUMN, id).update({ Name: name });
+        const row = await trx(TABLE).where(ID_COLUMN, id).first();
+        return mapGroup(row);
+      });
+    },
+
+    /**
+     * Deletes a group.
+     *
+     * @param {number} id
+     * @returns {Promise<number>}
+     */
+    async deleteGroup(id) {
+      return db.transaction((trx) => trx(TABLE).where(ID_COLUMN, id).del());
+    }
+  };
+}

--- a/data/hosts.js
+++ b/data/hosts.js
@@ -1,0 +1,138 @@
+import { resolveInsertedId } from './utils.js';
+
+/** @typedef {import('../server/types.js').Knex} Knex */
+/** @typedef {import('../server/types.js').Host} Host */
+
+/**
+ * Creates a repository for performing host-related database operations.
+ *
+ * @param {Knex} db
+ */
+export function createHostsRepository(db) {
+  const TABLE = 'hosts';
+  const ID_COLUMN = 'idHost';
+
+  /**
+   * @param {any} row
+   * @returns {Host | null}
+   */
+  function mapHost(row) {
+    if (!row) {
+      return null;
+    }
+
+    return {
+      id: row.idHost,
+      name: row.Name,
+      url: row.Url,
+      groupId: row.idGroup ?? null,
+      groupName: row.GroupName ?? null
+    };
+  }
+
+  /**
+   * @param {Knex | import('knex').Knex.Transaction} connection
+   * @param {number} id
+   */
+  async function fetchHost(connection, id) {
+    const row = await connection(TABLE)
+      .leftJoin('groups', 'hosts.idGroup', 'groups.idGroup')
+      .select(
+        'hosts.idHost',
+        'hosts.Name',
+        'hosts.Url',
+        'hosts.idGroup',
+        'groups.Name as GroupName'
+      )
+      .where('hosts.idHost', id)
+      .first();
+
+    return mapHost(row);
+  }
+
+  return {
+    /**
+     * Retrieves all hosts along with their associated group names.
+     *
+     * @returns {Promise<Host[]>}
+     */
+    async listHosts() {
+      const rows = await db(TABLE)
+        .leftJoin('groups', 'hosts.idGroup', 'groups.idGroup')
+        .select(
+          'hosts.idHost',
+          'hosts.Name',
+          'hosts.Url',
+          'hosts.idGroup',
+          'groups.Name as GroupName'
+        );
+
+      return rows.map((row) => mapHost(row)).filter(Boolean);
+    },
+
+    /**
+     * Retrieves a single host by its identifier.
+     *
+     * @param {number} id
+     * @returns {Promise<Host | null>}
+     */
+    async getHostById(id) {
+      return fetchHost(db, id);
+    },
+
+    /**
+     * Creates a new host record.
+     *
+     * @param {{ name: string; url: string; groupId?: number | null }} input
+     * @returns {Promise<Host | null>}
+     */
+    async createHost({ name, url, groupId = null }) {
+      return db.transaction(async (trx) => {
+        const insertData = {
+          Name: name,
+          Url: url,
+          idGroup: groupId ?? null
+        };
+
+        const insertResult = await trx(TABLE).insert(insertData);
+        const id = await resolveInsertedId(trx, TABLE, ID_COLUMN, insertResult);
+        if (id == null) {
+          return null;
+        }
+
+        return fetchHost(trx, id);
+      });
+    },
+
+    /**
+     * Updates an existing host record.
+     *
+     * @param {number} id
+     * @param {{ name: string; url: string; groupId?: number | null }} input
+     * @returns {Promise<Host | null>}
+     */
+    async updateHost(id, { name, url, groupId = null }) {
+      return db.transaction(async (trx) => {
+        await trx(TABLE)
+          .where(ID_COLUMN, id)
+          .update({
+            Name: name,
+            Url: url,
+            idGroup: groupId ?? null
+          });
+
+        return fetchHost(trx, id);
+      });
+    },
+
+    /**
+     * Deletes a host.
+     *
+     * @param {number} id
+     * @returns {Promise<number>}
+     */
+    async deleteHost(id) {
+      return db.transaction((trx) => trx(TABLE).where(ID_COLUMN, id).del());
+    }
+  };
+}

--- a/data/users.js
+++ b/data/users.js
@@ -1,0 +1,133 @@
+import { resolveInsertedId } from './utils.js';
+
+/** @typedef {import('../server/types.js').Knex} Knex */
+/** @typedef {import('../server/types.js').User} User */
+/** @typedef {import('../server/types.js').UserWithPassword} UserWithPassword */
+
+/**
+ * Creates a repository that encapsulates user persistence operations.
+ *
+ * @param {Knex} db
+ */
+export function createUsersRepository(db) {
+  const TABLE = 'users';
+  const ID_COLUMN = 'id';
+
+  /**
+   * @param {any} row
+   * @param {boolean} [includePassword]
+   * @returns {User | UserWithPassword | null}
+   */
+  function mapUser(row, includePassword = false) {
+    if (!row) {
+      return null;
+    }
+
+    const base = {
+      id: row.id,
+      name: row.Name,
+      email: row.Email,
+      role: row.Role
+    };
+
+    if (includePassword) {
+      return /** @type {UserWithPassword} */ ({ ...base, passwordHash: row.Password });
+    }
+
+    return base;
+  }
+
+  return {
+    /**
+     * Retrieves all users without password hashes.
+     *
+     * @returns {Promise<User[]>}
+     */
+    async listUsers() {
+      const rows = await db(TABLE).select('id', 'Name', 'Email', 'Role');
+      return rows.map((row) => mapUser(row)).filter(Boolean);
+    },
+
+    /**
+     * Retrieves a user by its identifier.
+     *
+     * @param {number} id
+     * @returns {Promise<User | null>}
+     */
+    async getUserById(id) {
+      const row = await db(TABLE).where(ID_COLUMN, id).first();
+      return /** @type {User | null} */ (mapUser(row));
+    },
+
+    /**
+     * Finds a user by email address, including the password hash.
+     *
+     * @param {string} email
+     * @returns {Promise<UserWithPassword | null>}
+     */
+    async findByEmail(email) {
+      const row = await db(TABLE).where('Email', email).first();
+      return /** @type {UserWithPassword | null} */ (mapUser(row, true));
+    },
+
+    /**
+     * Creates a new user record.
+     *
+     * @param {{ name: string; email: string; passwordHash: string; role: string }} input
+     * @returns {Promise<User | null>}
+     */
+    async createUser({ name, email, passwordHash, role }) {
+      return db.transaction(async (trx) => {
+        const insertResult = await trx(TABLE).insert({
+          Name: name,
+          Email: email,
+          Password: passwordHash,
+          Role: role
+        });
+
+        const id = await resolveInsertedId(trx, TABLE, ID_COLUMN, insertResult);
+        if (id == null) {
+          return null;
+        }
+
+        const row = await trx(TABLE).where(ID_COLUMN, id).first();
+        return /** @type {User | null} */ (mapUser(row));
+      });
+    },
+
+    /**
+     * Updates an existing user record.
+     *
+     * @param {number} id
+     * @param {{ name: string; email: string; role: string; passwordHash?: string | null }} input
+     * @returns {Promise<User | null>}
+     */
+    async updateUser(id, { name, email, role, passwordHash = null }) {
+      return db.transaction(async (trx) => {
+        const updateData = {
+          Name: name,
+          Email: email,
+          Role: role
+        };
+
+        if (passwordHash) {
+          updateData.Password = passwordHash;
+        }
+
+        await trx(TABLE).where(ID_COLUMN, id).update(updateData);
+        const row = await trx(TABLE).where(ID_COLUMN, id).first();
+        return /** @type {User | null} */ (mapUser(row));
+      });
+    },
+
+    /**
+     * Deletes a user.
+     *
+     * @param {number} id
+     * @returns {Promise<number>}
+     */
+    async deleteUser(id) {
+      return db.transaction((trx) => trx(TABLE).where(ID_COLUMN, id).del());
+    }
+  };
+}

--- a/data/utils.js
+++ b/data/utils.js
@@ -1,0 +1,67 @@
+/**
+ * Normalizes the result returned by Knex insert operations across
+ * different database drivers.
+ *
+ * @param {unknown} insertResult
+ * @param {string} idColumn
+ * @returns {number | string | null}
+ */
+export function normalizeInsertId(insertResult, idColumn) {
+  if (insertResult == null) {
+    return null;
+  }
+
+  if (Array.isArray(insertResult)) {
+    if (insertResult.length === 0) {
+      return null;
+    }
+
+    const value = insertResult[0];
+    if (typeof value === 'object' && value !== null) {
+      if (idColumn in value) {
+        return /** @type {any} */ (value)[idColumn];
+      }
+
+      const entries = Object.values(value);
+      return entries.length > 0 ? entries[0] : null;
+    }
+
+    return value;
+  }
+
+  if (typeof insertResult === 'object') {
+    const record = /** @type {Record<string, unknown>} */ (insertResult);
+    if (idColumn in record) {
+      return /** @type {any} */ (record[idColumn]);
+    }
+
+    const entries = Object.values(record);
+    return entries.length > 0 ? /** @type {any} */ (entries[0]) : null;
+  }
+
+  return /** @type {any} */ (insertResult);
+}
+
+/**
+ * Attempts to resolve the identifier of a newly inserted row.
+ *
+ * @param {import('knex').Knex.Transaction} trx
+ * @param {string} table
+ * @param {string} idColumn
+ * @param {unknown} insertResult
+ * @returns {Promise<number | null>}
+ */
+export async function resolveInsertedId(trx, table, idColumn, insertResult) {
+  const normalized = normalizeInsertId(insertResult, idColumn);
+  if (normalized != null && !Number.isNaN(Number(normalized))) {
+    return Number(normalized);
+  }
+
+  const fallback = await trx(table).max({ id: idColumn }).first();
+  if (!fallback) {
+    return null;
+  }
+
+  const id = fallback.id ?? fallback[idColumn];
+  return id == null || Number.isNaN(Number(id)) ? null : Number(id);
+}

--- a/server/context.js
+++ b/server/context.js
@@ -1,4 +1,7 @@
 import { createRequire } from 'module';
+import { createGroupsRepository } from '../data/groups.js';
+import { createHostsRepository } from '../data/hosts.js';
+import { createUsersRepository } from '../data/users.js';
 
 /** @typedef {import('./types.js').ServerContext} ServerContext */
 /** @typedef {import('./types.js').ServerConfig} ServerConfig */
@@ -23,9 +26,16 @@ export function createServerContext({ config, db, sessionStore, supervisordapi }
     throw new Error('Invalid server context configuration');
   }
 
+  const data = Object.freeze({
+    hosts: createHostsRepository(db),
+    groups: createGroupsRepository(db),
+    users: createUsersRepository(db)
+  });
+
   return Object.freeze({
     config,
     db,
+    data,
     sessionStore,
     supervisordapi,
     version: packageJson.version

--- a/server/session.js
+++ b/server/session.js
@@ -1,7 +1,7 @@
 import { ServiceError } from '../services/supervisordService.js';
 
 /** @typedef {import('./types.js').RequestSession} RequestSession */
-/** @typedef {import('./types.js').UserRow} UserRow */
+/** @typedef {import('./types.js').User} User */
 /** @typedef {import('express').Request} Request */
 /** @typedef {import('express').Response} Response */
 
@@ -9,7 +9,7 @@ import { ServiceError } from '../services/supervisordService.js';
  * Returns the authenticated user attached to the session.
  *
  * @param {RequestSession | undefined | null} session
- * @returns {UserRow | null}
+ * @returns {User | null}
  */
 export function getSessionUser(session) {
   return session?.user ?? null;
@@ -19,7 +19,7 @@ export function getSessionUser(session) {
  * Determines whether the provided session represents an authenticated user.
  *
  * @param {RequestSession | undefined | null} session
- * @returns {session is RequestSession & { loggedIn: true; user: UserRow }}
+ * @returns {session is RequestSession & { loggedIn: true; user: User }}
  */
 export function isSessionAuthenticated(session) {
   return Boolean(session?.loggedIn && session?.user);
@@ -32,7 +32,7 @@ export function isSessionAuthenticated(session) {
  * @returns {boolean}
  */
 export function isSessionAdmin(session) {
-  return isSessionAuthenticated(session) && getSessionUser(session)?.Role === 'Admin';
+  return isSessionAuthenticated(session) && getSessionUser(session)?.role === 'Admin';
 }
 
 /**
@@ -81,7 +81,7 @@ export function ensureAdminRequest(req, res, redirectTo = '/dashboard') {
  * redirects are undesirable.
  *
  * @param {RequestSession | undefined | null} session
- * @returns {RequestSession & { loggedIn: true; user: UserRow }}
+ * @returns {RequestSession & { loggedIn: true; user: User }}
  * @throws {ServiceError}
  */
 export function assertSessionAuthenticated(session) {
@@ -97,7 +97,7 @@ export function assertSessionAuthenticated(session) {
  * {@link ServiceError} when the requirement is not satisfied.
  *
  * @param {RequestSession | undefined | null} session
- * @returns {RequestSession & { loggedIn: true; user: UserRow }}
+ * @returns {RequestSession & { loggedIn: true; user: User }}
  * @throws {ServiceError}
  */
 export function assertSessionAdmin(session) {

--- a/server/types.js
+++ b/server/types.js
@@ -38,12 +38,74 @@ export let HostRow;
 export let UserRow;
 
 /**
+ * @typedef {Object} Group
+ * @property {number} id
+ * @property {string} name
+ */
+export let Group;
+
+/**
+ * @typedef {Object} Host
+ * @property {number} id
+ * @property {string} name
+ * @property {string} url
+ * @property {number|null} [groupId]
+ * @property {string|null} [groupName]
+ */
+export let Host;
+
+/**
+ * @typedef {Object} User
+ * @property {number} id
+ * @property {string} name
+ * @property {string} email
+ * @property {string} role
+ */
+export let User;
+
+/**
+ * @typedef {User & { passwordHash: string }} UserWithPassword
+ */
+export let UserWithPassword;
+
+/**
  * @typedef {import('express-session').Session & import('express-session').SessionData & {
  *   loggedIn?: boolean;
- *   user?: UserRow | null;
+ *   user?: User | null;
  * }} RequestSession
  */
 export let RequestSession;
+
+/**
+ * @typedef {Object} HostRepository
+ * @property {() => Promise<Host[]>} listHosts
+ * @property {(id: number) => Promise<Host | null>} getHostById
+ * @property {(input: { name: string; url: string; groupId?: number | null }) => Promise<Host | null>} createHost
+ * @property {(id: number, input: { name: string; url: string; groupId?: number | null }) => Promise<Host | null>} updateHost
+ * @property {(id: number) => Promise<number>} deleteHost
+ */
+export let HostRepository;
+
+/**
+ * @typedef {Object} GroupRepository
+ * @property {() => Promise<Group[]>} listGroups
+ * @property {(id: number) => Promise<Group | null>} getGroupById
+ * @property {(input: { name: string }) => Promise<Group | null>} createGroup
+ * @property {(id: number, input: { name: string }) => Promise<Group | null>} updateGroup
+ * @property {(id: number) => Promise<number>} deleteGroup
+ */
+export let GroupRepository;
+
+/**
+ * @typedef {Object} UserRepository
+ * @property {() => Promise<User[]>} listUsers
+ * @property {(id: number) => Promise<User | null>} getUserById
+ * @property {(email: string) => Promise<UserWithPassword | null>} findByEmail
+ * @property {(input: { name: string; email: string; passwordHash: string; role: string }) => Promise<User | null>} createUser
+ * @property {(id: number, input: { name: string; email: string; role: string; passwordHash?: string | null }) => Promise<User | null>} updateUser
+ * @property {(id: number) => Promise<number>} deleteUser
+ */
+export let UserRepository;
 
 /**
  * @typedef {Object} HostOverrideConnection
@@ -150,6 +212,11 @@ export let ServerConfig;
  * @typedef {Object} ServerContext
  * @property {ServerConfig} config
  * @property {Knex} db
+ * @property {{
+ *   hosts: HostRepository;
+ *   groups: GroupRepository;
+ *   users: UserRepository;
+ * }} data
  * @property {SessionStore} sessionStore
  * @property {typeof import('supervisord')} supervisordapi
  * @property {string} [version]

--- a/views/edit_group.ejs
+++ b/views/edit_group.ejs
@@ -6,14 +6,14 @@
             <div class="main clearfix">
                 <article>
 
-                    <h2><%= (group === null) ? 'New Group' : 'Edit ' + group.Name %></h2>
+                    <h2><%= (group === null) ? 'New Group' : 'Edit ' + group.name %></h2>
                     <hr>
                     <form method="post" role="form">
                         <div class="row" style="margin-left: -15px;">
                             <div class="col-md-4">
                                 <div class="form-group">
                                     <label for="inputName" class="control-label">Name</label>
-                                    <input type="text" name="name" class="form-control" id="inputName" placeholder="Name"  value="<%= (group === null) ? '' : group.Name %>">
+                                    <input type="text" name="name" class="form-control" id="inputName" placeholder="Name"  value="<%= (group === null) ? '' : group.name %>">
                                 </div>
                                 <div class="form-group">
                                     <button type="submit" name="submit" class="btn btn-success">Save</button>

--- a/views/edit_host.ejs
+++ b/views/edit_host.ejs
@@ -6,25 +6,25 @@
             <div class="main clearfix">
                 <article>
 
-                    <h2><%= (host === null) ? 'New Host' : 'Edit ' + host.Name %></h2>
+                    <h2><%= (host === null) ? 'New Host' : 'Edit ' + host.name %></h2>
                     <hr>
                     <form method="post" role="form">
                         <div class="row" style="margin-left: -15px;">
                             <div class="col-md-4">
                                 <div class="form-group">
                                     <label for="inputName" class="control-label">Name</label>
-                                    <input type="text" name="name" class="form-control" id="inputName" <%= (host === null) ? 'placeholder=Name' : 'value=' + host.Name %> >
+                                    <input type="text" name="name" class="form-control" id="inputName" <%= (host === null) ? 'placeholder=Name' : 'value=' + host.name %> >
                                 </div>
                                 <div class="form-group">
                                     <label for="inputUrl" class="control-label">Url</label>
-                                    <input type="text" name="url" class="form-control" id="inputUrl" <%= (host === null) ? 'placeholder=http://hostname:9009' : 'value=' + host.Url %> >
+                                    <input type="text" name="url" class="form-control" id="inputUrl" <%= (host === null) ? 'placeholder=http://hostname:9009' : 'value=' + host.url %> >
                                 </div>
                                 <div class="form-group">
                                     <label for="inputGroup" class="control-label">Group</label>
                                     <select name="group" id="inputGroup" class="form-control">
                                         <option value="null">No Group</option>
                                         <% for (group in groups) { %>
-                                            <option <%= (host !== null) ? ((host.idGroup == groups[group].idGroup) ? 'selected' : '') : '' %> value="<%= groups[group].idGroup %>"><%= groups[group].Name %></option>
+                                            <option <%= (host !== null) ? ((host.groupId == groups[group].id) ? 'selected' : '') : '' %> value="<%= groups[group].id %>"><%= groups[group].name %></option>
                                         <% } %>
                                     </select>
                                 </div>

--- a/views/edit_user.ejs
+++ b/views/edit_user.ejs
@@ -6,18 +6,18 @@
             <div class="main clearfix">
                 <article>
 
-                    <h2><%= (user === null) ? 'New User' : user.Name %></h2>
+                    <h2><%= (user === null) ? 'New User' : user.name %></h2>
                     <hr>
                     <form method="post" role="form">
                         <div class="row" style="margin-left: -15px;">
                             <div class="col-md-4">
                                 <div class="form-group">
                                     <label for="inputName" class="control-label">Name</label>
-                                    <input type="text" name="name" class="form-control" id="inputName" <%= (user === null) ? 'placeholder=Name' : 'value=' + user.Name %> >
+                                    <input type="text" name="name" class="form-control" id="inputName" <%= (user === null) ? 'placeholder=Name' : 'value=' + user.name %> >
                                 </div>
                                 <div class="form-group">
                                     <label for="inputEmail" class="control-label">Email</label>
-                                    <input type="email" name="email" class="form-control" id="inputEmail" <%= (user === null) ? 'placeholder=email@domain.com' : 'value=' + user.Email %> >
+                                    <input type="email" name="email" class="form-control" id="inputEmail" <%= (user === null) ? 'placeholder=email@domain.com' : 'value=' + user.email %> >
                                 </div>
                                 <div class="form-group">
                                     <label for="inputPassword" class="control-label">Password</label>
@@ -26,8 +26,8 @@
                                 <div class="form-group">
                                     <label for="inputRole" class="control-label">Role</label>
                                     <select name="role" id="inputRole" class="form-control">
-                                        <option <%= (user !== null) ? ((user.Role == 'User') ? 'selected' : '') : '' %> value="User">User</option>
-                                        <option <%= (user !== null) ? ((user.Role == 'Admin') ? 'selected' : '') : '' %> value="Admin">Admin</option>
+                                        <option <%= (user !== null) ? ((user.role == 'User') ? 'selected' : '') : '' %> value="User">User</option>
+                                        <option <%= (user !== null) ? ((user.role == 'Admin') ? 'selected' : '') : '' %> value="Admin">Admin</option>
                                     </select>
                                 </div>
                                 <div class="form-group">

--- a/views/groups.ejs
+++ b/views/groups.ejs
@@ -17,8 +17,8 @@
                             </tr>
                             <% for (group in groups) { %>
                                 <tr>
-                                    <td><%= groups[group].Name %></td>
-                                    <td><a href="/group/<%= groups[group].idGroup %>" class="btn btn-default"><i class="glyphicon glyphicon-edit"></i></a></td>
+                                    <td><%= groups[group].name %></td>
+                                    <td><a href="/group/<%= groups[group].id %>" class="btn btn-default"><i class="glyphicon glyphicon-edit"></i></a></td>
                                 </tr>
                             <% } %>
                         </table>

--- a/views/hosts.ejs
+++ b/views/hosts.ejs
@@ -19,10 +19,10 @@
                             </tr>
                             <% for (host in hosts) { %>
                                 <tr>
-                                    <td><%= hosts[host].Name %></td>
-                                    <td><%= hosts[host].Url %></td>
-                                    <td><%= hosts[host].GroupName != null ? hosts[host].GroupName : '' %></td>
-                                    <td><a href="/host/<%= hosts[host].idHost %>" class="btn btn-default"><i class="glyphicon glyphicon-edit"></i></a></td>
+                                    <td><%= hosts[host].name %></td>
+                                    <td><%= hosts[host].url %></td>
+                                    <td><%= hosts[host].groupName != null ? hosts[host].groupName : '' %></td>
+                                    <td><a href="/host/<%= hosts[host].id %>" class="btn btn-default"><i class="glyphicon glyphicon-edit"></i></a></td>
                                 </tr>
                             <% } %>
                         </table>

--- a/views/menu.ejs
+++ b/views/menu.ejs
@@ -5,8 +5,8 @@
 	        <nav>
 	            <ul>
 	                <%
-	                	if (typeof session.user != 'undefined') {
-	                		if (session.user.Role == 'Admin') {
+                                if (typeof session.user != 'undefined') {
+                                        if (session.user.role == 'Admin') {
                 			%>
                                 <li><a href="/">Home</a></li>
                                 <li><a href="/hosts">Hosts</a></li>

--- a/views/supervisord.ejs
+++ b/views/supervisord.ejs
@@ -31,7 +31,7 @@
         <%
             var sessRole = '';
             if (typeof session.user != 'undefined'){
-                sessRole = session.user.Role;
+                sessRole = session.user.role;
             }
         %>
         var uiRole = '<%= sessRole %>';

--- a/views/users.ejs
+++ b/views/users.ejs
@@ -19,9 +19,9 @@
                             </tr>
                             <% for (user in users) { %>
                                 <tr>
-                                    <td><%= users[user].Name %></td>
-                                    <td><%= users[user].Email %></td>
-                                    <td><%= users[user].Role %></td>
+                                    <td><%= users[user].name %></td>
+                                    <td><%= users[user].email %></td>
+                                    <td><%= users[user].role %></td>
                                     <td><a href="/user/<%= users[user].id %>" class="btn btn-default"><i class="glyphicon glyphicon-edit"></i></a></td>
                                 </tr>
                             <% } %>


### PR DESCRIPTION
## Summary
- add data access repositories for hosts, groups, and users with shared insert helpers
- wire the repositories into the server context and refactor routes/views to consume normalized records
- expand the automated test suite with repository unit tests and updated app stubs

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d5752b3f84832e9bb04b2901747222