### PR TITLE
feat: modernize database support

### DIFF
--- a/.env-example
+++ b/.env-example
@@ -17,6 +17,16 @@ SESSION_COOKIE_MAX_AGE=604800000
 # Primary application database
 DB_CLIENT=sqlite3
 DB_FILENAME=./nodervisor.sqlite
+# Example MySQL configuration
+# DB_CLIENT=mysql2
+# DB_HOST=localhost
+# DB_PORT=3306
+# DB_NAME=nodervisor
+# DB_USER=root
+# DB_PASSWORD=root
+# DB_POOL_MIN=2
+# DB_POOL_MAX=10
+
 # Example PostgreSQL configuration
 # DB_CLIENT=pg
 # DB_HOST=localhost

--- a/.github/workflows/migrations.yml
+++ b/.github/workflows/migrations.yml
@@ -1,0 +1,79 @@
+name: Database checks
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+
+jobs:
+  sqlite:
+    name: SQLite migrations
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Run migrations
+        run: npm run migrate
+
+      - name: Seed database
+        run: npm run seed
+
+  mysql:
+    name: MySQL migrations
+    runs-on: ubuntu-latest
+    services:
+      mysql:
+        image: mysql:8
+        env:
+          MYSQL_ROOT_PASSWORD: root
+          MYSQL_DATABASE: nodervisor
+        ports:
+          - 3306:3306
+        options: >-
+          --health-cmd "mysqladmin ping -h 127.0.0.1 -uroot -proot"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Wait for MySQL
+        run: npx --yes wait-on tcp:127.0.0.1:3306
+
+      - name: Run migrations
+        run: npm run migrate
+        env:
+          DB_CLIENT: mysql2
+          DB_HOST: 127.0.0.1
+          DB_PORT: 3306
+          DB_NAME: nodervisor
+          DB_USER: root
+          DB_PASSWORD: root
+
+      - name: Seed database
+        run: npm run seed
+        env:
+          DB_CLIENT: mysql2
+          DB_HOST: 127.0.0.1
+          DB_PORT: 3306
+          DB_NAME: nodervisor
+          DB_USER: root
+          DB_PASSWORD: root

--- a/README.md
+++ b/README.md
@@ -24,6 +24,39 @@ A Supervisord manager in node.js. Nodervisor provides a real-time web dashboard 
         DB_FILENAME=./nodervisor.sqlite
         SESSION_SECRET=use-a-long-random-string
 
+  3. Run the database migrations and seed data:
+
+        npm run migrate
+        npm run seed
+
+### Database configuration
+
+Nodervisor uses [Knex](https://knexjs.org/) for database access. The default configuration relies on SQLite, but MySQL (via the [`mysql2`](https://www.npmjs.com/package/mysql2) driver) and PostgreSQL (via [`pg`](https://www.npmjs.com/package/pg)) are also supported. Select a database by setting `DB_CLIENT` and the related connection settings in your environment:
+
+```
+# SQLite (default)
+DB_CLIENT=sqlite3
+DB_FILENAME=./nodervisor.sqlite
+
+# MySQL
+DB_CLIENT=mysql2
+DB_HOST=localhost
+DB_PORT=3306
+DB_NAME=nodervisor
+DB_USER=root
+DB_PASSWORD=root
+
+# PostgreSQL
+DB_CLIENT=pg
+DB_HOST=localhost
+DB_PORT=5432
+DB_NAME=nodervisor
+DB_USER=postgres
+DB_PASSWORD=postgres
+```
+
+The session store uses the same connection details by default, but you can override it with the `SESSION_DB_*` variables when needed.
+
 ### How to use it
 
   Run the app using:

--- a/config.js
+++ b/config.js
@@ -247,11 +247,13 @@ function createDatabaseConfig({
   poolMin,
   poolMax
 }) {
+  const normalizedClient = normalizeClientName(client);
+
   const config = {
-    client
+    client: normalizedClient
   };
 
-  if (client === 'sqlite3') {
+  if (normalizedClient === 'sqlite3') {
     config.connection = { filename };
     config.useNullAsDefault = true;
   } else {
@@ -274,6 +276,24 @@ function createDatabaseConfig({
   }
 
   return config;
+}
+
+function normalizeClientName(client) {
+  if (!client) {
+    return client;
+  }
+
+  const normalized = client.toLowerCase();
+
+  if (normalized === 'mysql') {
+    return 'mysql2';
+  }
+
+  if (normalized === 'postgres' || normalized === 'postgresql') {
+    return 'pg';
+  }
+
+  return client;
 }
 
 function createDashboardConfig({ publicDir, publicPath, entry, manifestList }) {

--- a/knexfile.cjs
+++ b/knexfile.cjs
@@ -1,22 +1,143 @@
-const path = require('path');
+const fs = require('node:fs');
+const path = require('node:path');
 
-const baseConfig = {
-  client: 'sqlite3',
-  connection: {
-    filename: path.resolve(__dirname, 'nodervisor.sqlite')
-  },
-  useNullAsDefault: true,
+const { config: loadEnv } = require('dotenv');
+
+const projectRoot = __dirname;
+
+loadEnvironmentFiles(projectRoot);
+
+const sharedConfig = {
   migrations: {
-    directory: path.resolve(__dirname, 'migrations'),
+    directory: path.resolve(projectRoot, 'migrations'),
     extension: 'cjs'
   },
   seeds: {
-    directory: path.resolve(__dirname, 'seeds'),
+    directory: path.resolve(projectRoot, 'seeds'),
     extension: 'cjs'
   }
 };
 
 module.exports = {
-  development: { ...baseConfig },
-  production: { ...baseConfig }
+  development: buildConfig('development', {
+    client: 'sqlite3',
+    filename: path.resolve(projectRoot, 'nodervisor.sqlite')
+  }),
+  test: buildConfig('test', {
+    client: 'sqlite3',
+    filename: path.resolve(projectRoot, 'nodervisor.test.sqlite')
+  }),
+  production: buildConfig('production', {
+    client: process.env.DB_CLIENT ?? 'sqlite3',
+    filename: path.resolve(projectRoot, 'nodervisor.sqlite')
+  })
 };
+
+function buildConfig(envName, defaults) {
+  const prefix = envName === 'production' ? 'DB' : `${envName.toUpperCase()}_DB`;
+  const client = normalizeClientName(
+    process.env[`${prefix}_CLIENT`] ?? process.env.DB_CLIENT ?? defaults.client
+  );
+
+  const base = { ...sharedConfig, client };
+
+  if (client === 'sqlite3') {
+    const filename = resolvePath(
+      process.env[`${prefix}_FILENAME`] ?? process.env.DB_FILENAME ?? defaults.filename
+    );
+    return {
+      ...base,
+      connection: { filename },
+      useNullAsDefault: true
+    };
+  }
+
+  const connection = filterUndefined({
+    host: process.env[`${prefix}_HOST`] ?? process.env.DB_HOST,
+    port: parseInteger(process.env[`${prefix}_PORT`] ?? process.env.DB_PORT),
+    database: process.env[`${prefix}_NAME`] ?? process.env.DB_NAME,
+    user: process.env[`${prefix}_USER`] ?? process.env.DB_USER,
+    password: process.env[`${prefix}_PASSWORD`] ?? process.env.DB_PASSWORD
+  });
+
+  const pool = filterUndefined({
+    min: parseInteger(process.env[`${prefix}_POOL_MIN`] ?? process.env.DB_POOL_MIN),
+    max: parseInteger(process.env[`${prefix}_POOL_MAX`] ?? process.env.DB_POOL_MAX)
+  });
+
+  const config = {
+    ...base,
+    connection
+  };
+
+  if (Object.keys(pool).length > 0) {
+    config.pool = pool;
+  }
+
+  return config;
+}
+
+function resolvePath(candidate) {
+  if (!candidate) {
+    return candidate;
+  }
+
+  return path.isAbsolute(candidate) ? candidate : path.resolve(projectRoot, candidate);
+}
+
+function parseInteger(value) {
+  if (value === undefined || value === null || value === '') {
+    return undefined;
+  }
+
+  const parsed = Number(value);
+  return Number.isFinite(parsed) && Number.isInteger(parsed) ? parsed : undefined;
+}
+
+function filterUndefined(record) {
+  return Object.fromEntries(
+    Object.entries(record).filter(([, value]) => value !== undefined && value !== null)
+  );
+}
+
+function normalizeClientName(client) {
+  if (!client) {
+    return client;
+  }
+
+  const normalized = client.toLowerCase();
+
+  if (normalized === 'mysql') {
+    return 'mysql2';
+  }
+
+  if (normalized === 'postgres' || normalized === 'postgresql') {
+    return 'pg';
+  }
+
+  return client;
+}
+
+function loadEnvironmentFiles(rootDir) {
+  const envName = process.env.ENV || process.env.NODE_ENV;
+
+  const candidates = [path.join(rootDir, '.env')];
+  if (envName) {
+    candidates.push(path.join(rootDir, `.env.${envName}`));
+  }
+  candidates.push(path.join(rootDir, '.env.local'));
+  if (envName) {
+    candidates.push(path.join(rootDir, `.env.${envName}.local`));
+  }
+
+  for (const [index, filePath] of candidates.entries()) {
+    if (!fs.existsSync(filePath)) {
+      continue;
+    }
+
+    loadEnv({
+      path: filePath,
+      override: index >= 2
+    });
+  }
+}

--- a/migrations/20240912121001_create_sessions_table.cjs
+++ b/migrations/20240912121001_create_sessions_table.cjs
@@ -1,0 +1,28 @@
+/**
+ * @param {import('knex')} knex
+ */
+exports.up = async function up(knex) {
+  const hasSessions = await knex.schema.hasTable('sessions');
+  if (hasSessions) {
+    return;
+  }
+
+  await knex.schema.createTable('sessions', (table) => {
+    table.string('sid', 255).primary();
+    table.text('sess').notNullable();
+    table.dateTime('expired').notNullable();
+    table.index(['expired'], 'sessions_expired_idx');
+  });
+};
+
+/**
+ * @param {import('knex')} knex
+ */
+exports.down = async function down(knex) {
+  const hasSessions = await knex.schema.hasTable('sessions');
+  if (!hasSessions) {
+    return;
+  }
+
+  await knex.schema.dropTable('sessions');
+};

--- a/package-lock.json
+++ b/package-lock.json
@@ -20,7 +20,8 @@
         "knex": "^3.1.0",
         "method-override": "^3.0.0",
         "morgan": "^1.10.0",
-        "mysql": "^2.18.1",
+        "mysql2": "^3.11.4",
+        "pg": "^8.13.1",
         "react": "^18.3.1",
         "react-dom": "^18.3.1",
         "serve-favicon": "^2.5.1",
@@ -3145,6 +3146,15 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/aws-ssl-profiles": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/aws-ssl-profiles/-/aws-ssl-profiles-1.1.2.tgz",
+      "integrity": "sha512-NZKeq9AfyQvEeNlN0zSYAaWrmBffJh3IELMZfRpJVWgrpEbtEpnjvzqBPf+mxoI287JohRDoa+/nsfqqiZmF6g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 6.0.0"
+      }
+    },
     "node_modules/babel-jest": {
       "version": "30.1.2",
       "resolved": "https://registry.npmjs.org/babel-jest/-/babel-jest-30.1.2.tgz",
@@ -3312,15 +3322,6 @@
       },
       "engines": {
         "node": ">= 18"
-      }
-    },
-    "node_modules/bignumber.js": {
-      "version": "9.0.0",
-      "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-9.0.0.tgz",
-      "integrity": "sha512-t/OYhhJ2SD+YGBQcjY8GzzDHEk9f3nerxjtfa6tlMXfe7frs/WozhvCNoGvpM0P3bNf3Gq5ZRMlGr5f3r4/N8A==",
-      "license": "MIT",
-      "engines": {
-        "node": "*"
       }
     },
     "node_modules/bindings": {
@@ -3894,12 +3895,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/core-util-is": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.3.tgz",
-      "integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==",
-      "license": "MIT"
-    },
     "node_modules/cross-env": {
       "version": "10.0.0",
       "resolved": "https://registry.npmjs.org/cross-env/-/cross-env-10.0.0.tgz",
@@ -4013,6 +4008,15 @@
       "integrity": "sha512-bd2L678uiWATM6m5Z1VzNCErI3jiGzt6HGY8OVICs40JQq/HALfbyNJmp0UDakEY4pMMaN0Ly5om/B1VI/+xfQ==",
       "license": "MIT",
       "optional": true
+    },
+    "node_modules/denque": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/denque/-/denque-2.1.0.tgz",
+      "integrity": "sha512-HVQE3AAb/pxF8fQAoiqpvg9i3evqug3hoiwakOyZAwJm+6vZehbkYXZ0l4JxS+I3QxM97v5aaRNhj8v5oBhekw==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=0.10"
+      }
     },
     "node_modules/depd": {
       "version": "2.0.0",
@@ -5015,6 +5019,15 @@
         "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
       }
     },
+    "node_modules/generate-function": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/generate-function/-/generate-function-2.3.1.tgz",
+      "integrity": "sha512-eeB5GfMNeevm/GRYq20ShmsaGcmI81kIX2K9XQx5miC8KdHaC6Jm0qQ8ZNeGOi7wYB8OsdxKs+Y2oVuTFuVwKQ==",
+      "license": "MIT",
+      "dependencies": {
+        "is-property": "^1.0.2"
+      }
+    },
     "node_modules/gensync": {
       "version": "1.0.0-beta.2",
       "resolved": "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.2.tgz",
@@ -5632,6 +5645,12 @@
         "node": ">=0.12.0"
       }
     },
+    "node_modules/is-property": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/is-property/-/is-property-1.0.2.tgz",
+      "integrity": "sha512-Ks/IoX00TtClbGQr4TWXemAnktAQvYB7HzcCxDGqEZU6oCmb2INHuOoKxbtR+HFkmYWBKv/dOZtGRiAjDhj92g==",
+      "license": "MIT"
+    },
     "node_modules/is-stream": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.1.tgz",
@@ -5644,12 +5663,6 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
-    },
-    "node_modules/isarray": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-      "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==",
-      "license": "MIT"
     },
     "node_modules/isexe": {
       "version": "2.0.0",
@@ -6702,6 +6715,12 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/long": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/long/-/long-5.3.2.tgz",
+      "integrity": "sha512-mNAgZ1GmyNhD7AuqnTG3/VQ26o760+ZYBPKjPvugO8+nLbYfX6TVpJPseBvopbdY+qpZ/lKUnmEc1LeZYS3QAA==",
+      "license": "Apache-2.0"
+    },
     "node_modules/loose-envify": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
@@ -6725,6 +6744,21 @@
       },
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/lru.min": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/lru.min/-/lru.min-1.1.2.tgz",
+      "integrity": "sha512-Nv9KddBcQSlQopmBHXSsZVY5xsdlZkdH/Iey0BlcBYggMd4two7cZnKOK9vmy3nY0O5RGH99z1PCeTpPqszUYg==",
+      "license": "MIT",
+      "engines": {
+        "bun": ">=1.0.0",
+        "deno": ">=1.30.0",
+        "node": ">=8.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wellwelwel"
       }
     },
     "node_modules/make-dir": {
@@ -7085,26 +7119,71 @@
       "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
       "license": "MIT"
     },
-    "node_modules/mysql": {
-      "version": "2.18.1",
-      "resolved": "https://registry.npmjs.org/mysql/-/mysql-2.18.1.tgz",
-      "integrity": "sha512-Bca+gk2YWmqp2Uf6k5NFEurwY/0td0cpebAucFpY/3jhrwrVGuxU2uQFCHjU19SJfje0yQvi+rVWdq78hR5lig==",
+    "node_modules/mysql2": {
+      "version": "3.15.1",
+      "resolved": "https://registry.npmjs.org/mysql2/-/mysql2-3.15.1.tgz",
+      "integrity": "sha512-WZMIRZstT2MFfouEaDz/AGFnGi1A2GwaDe7XvKTdRJEYiAHbOrh4S3d8KFmQeh11U85G+BFjIvS1Di5alusZsw==",
       "license": "MIT",
       "dependencies": {
-        "bignumber.js": "9.0.0",
-        "readable-stream": "2.3.7",
-        "safe-buffer": "5.1.2",
-        "sqlstring": "2.3.1"
+        "aws-ssl-profiles": "^1.1.1",
+        "denque": "^2.1.0",
+        "generate-function": "^2.3.1",
+        "iconv-lite": "^0.7.0",
+        "long": "^5.2.1",
+        "lru.min": "^1.0.0",
+        "named-placeholders": "^1.1.3",
+        "seq-queue": "^0.0.5",
+        "sqlstring": "^2.3.2"
       },
+      "engines": {
+        "node": ">= 8.0"
+      }
+    },
+    "node_modules/mysql2/node_modules/iconv-lite": {
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.0.tgz",
+      "integrity": "sha512-cf6L2Ds3h57VVmkZe+Pn+5APsT7FpqJtEhhieDCvrE2MK5Qk9MyffgQyuxQTm6BChfeZNtcOLHp9IcWRVcIcBQ==",
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/mysql2/node_modules/sqlstring": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/sqlstring/-/sqlstring-2.3.3.tgz",
+      "integrity": "sha512-qC9iz2FlN7DQl3+wjwn3802RTyjCx7sDvfQEXchwa6CWOx07/WVfh91gBmQ9fahw8snwGEWU3xGzOt4tFyHLxg==",
+      "license": "MIT",
       "engines": {
         "node": ">= 0.6"
       }
     },
-    "node_modules/mysql/node_modules/safe-buffer": {
-      "version": "5.1.2",
-      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
-      "license": "MIT"
+    "node_modules/named-placeholders": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/named-placeholders/-/named-placeholders-1.1.3.tgz",
+      "integrity": "sha512-eLoBxg6wE/rZkJPhU/xRX1WTpkFEwDJEN96oxFrTsqBdbT5ec295Q+CoHrL9IT0DipqKhmGcaZmwOt8OON5x1w==",
+      "license": "MIT",
+      "dependencies": {
+        "lru-cache": "^7.14.1"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/named-placeholders/node_modules/lru-cache": {
+      "version": "7.18.3",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-7.18.3.tgz",
+      "integrity": "sha512-jumlc0BIUrS3qJGgIkWZsyfAM7NCWiBcCDhnd+3NNM5KbBmLTgHVfWBcg6W+rLUsIpzpERPsvwUP7CckAQSOoA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
     },
     "node_modules/nanoid": {
       "version": "3.3.11",
@@ -7543,11 +7622,100 @@
       "integrity": "sha512-RA1GjUVMnvYFxuqovrEqZoxxW5NUZqbwKtYz/Tt7nXerk0LbLblQmrsgdeOxV5SFHf0UDggjS/bSeOZwt1pmEQ==",
       "license": "MIT"
     },
+    "node_modules/pg": {
+      "version": "8.16.3",
+      "resolved": "https://registry.npmjs.org/pg/-/pg-8.16.3.tgz",
+      "integrity": "sha512-enxc1h0jA/aq5oSDMvqyW3q89ra6XIIDZgCX9vkMrnz5DFTw/Ny3Li2lFQ+pt3L6MCgm/5o2o8HW9hiJji+xvw==",
+      "license": "MIT",
+      "dependencies": {
+        "pg-connection-string": "^2.9.1",
+        "pg-pool": "^3.10.1",
+        "pg-protocol": "^1.10.3",
+        "pg-types": "2.2.0",
+        "pgpass": "1.0.5"
+      },
+      "engines": {
+        "node": ">= 16.0.0"
+      },
+      "optionalDependencies": {
+        "pg-cloudflare": "^1.2.7"
+      },
+      "peerDependencies": {
+        "pg-native": ">=3.0.1"
+      },
+      "peerDependenciesMeta": {
+        "pg-native": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/pg-cloudflare": {
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/pg-cloudflare/-/pg-cloudflare-1.2.7.tgz",
+      "integrity": "sha512-YgCtzMH0ptvZJslLM1ffsY4EuGaU0cx4XSdXLRFae8bPP4dS5xL1tNB3k2o/N64cHJpwU7dxKli/nZ2lUa5fLg==",
+      "license": "MIT",
+      "optional": true
+    },
     "node_modules/pg-connection-string": {
       "version": "2.6.2",
       "resolved": "https://registry.npmjs.org/pg-connection-string/-/pg-connection-string-2.6.2.tgz",
       "integrity": "sha512-ch6OwaeaPYcova4kKZ15sbJ2hKb/VP48ZD2gE7i1J+L4MspCtBMAx8nMgz7bksc7IojCIIWuEhHibSMFH8m8oA==",
       "license": "MIT"
+    },
+    "node_modules/pg-int8": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/pg-int8/-/pg-int8-1.0.1.tgz",
+      "integrity": "sha512-WCtabS6t3c8SkpDBUlb1kjOs7l66xsGdKpIPZsg4wR+B3+u9UAum2odSsF9tnvxg80h4ZxLWMy4pRjOsFIqQpw==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
+    "node_modules/pg-pool": {
+      "version": "3.10.1",
+      "resolved": "https://registry.npmjs.org/pg-pool/-/pg-pool-3.10.1.tgz",
+      "integrity": "sha512-Tu8jMlcX+9d8+QVzKIvM/uJtp07PKr82IUOYEphaWcoBhIYkoHpLXN3qO59nAI11ripznDsEzEv8nUxBVWajGg==",
+      "license": "MIT",
+      "peerDependencies": {
+        "pg": ">=8.0"
+      }
+    },
+    "node_modules/pg-protocol": {
+      "version": "1.10.3",
+      "resolved": "https://registry.npmjs.org/pg-protocol/-/pg-protocol-1.10.3.tgz",
+      "integrity": "sha512-6DIBgBQaTKDJyxnXaLiLR8wBpQQcGWuAESkRBX/t6OwA8YsqP+iVSiond2EDy6Y/dsGk8rh/jtax3js5NeV7JQ==",
+      "license": "MIT"
+    },
+    "node_modules/pg-types": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/pg-types/-/pg-types-2.2.0.tgz",
+      "integrity": "sha512-qTAAlrEsl8s4OiEQY69wDvcMIdQN6wdz5ojQiOy6YRMuynxenON0O5oCpJI6lshc6scgAY8qvJ2On/p+CXY0GA==",
+      "license": "MIT",
+      "dependencies": {
+        "pg-int8": "1.0.1",
+        "postgres-array": "~2.0.0",
+        "postgres-bytea": "~1.0.0",
+        "postgres-date": "~1.0.4",
+        "postgres-interval": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/pg/node_modules/pg-connection-string": {
+      "version": "2.9.1",
+      "resolved": "https://registry.npmjs.org/pg-connection-string/-/pg-connection-string-2.9.1.tgz",
+      "integrity": "sha512-nkc6NpDcvPVpZXxrreI/FOtX3XemeLl8E0qFr6F2Lrm/I8WOnaWNhIPK2Z7OHpw7gh5XJThi6j6ppgNoaT1w4w==",
+      "license": "MIT"
+    },
+    "node_modules/pgpass": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/pgpass/-/pgpass-1.0.5.tgz",
+      "integrity": "sha512-FdW9r/jQZhSeohs1Z3sI1yxFQNFvMcnmfuj4WBMUTxOrAyLMaTcE1aAMBiTlbMNaXvBCQuVi0R7hd8udDSP7ug==",
+      "license": "MIT",
+      "dependencies": {
+        "split2": "^4.1.0"
+      }
     },
     "node_modules/picocolors": {
       "version": "1.1.1",
@@ -7676,6 +7844,45 @@
         "node": "^10 || ^12 || >=14"
       }
     },
+    "node_modules/postgres-array": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/postgres-array/-/postgres-array-2.0.0.tgz",
+      "integrity": "sha512-VpZrUqU5A69eQyW2c5CA1jtLecCsN2U/bD6VilrFDWq5+5UIEVO7nazS3TEcHf1zuPYO/sqGvUvW62g86RXZuA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/postgres-bytea": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/postgres-bytea/-/postgres-bytea-1.0.0.tgz",
+      "integrity": "sha512-xy3pmLuQqRBZBXDULy7KbaitYqLcmxigw14Q5sj8QBVLqEwXfeybIKVWiqAXTlcvdvb0+xkOtDbfQMOf4lST1w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/postgres-date": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/postgres-date/-/postgres-date-1.0.7.tgz",
+      "integrity": "sha512-suDmjLVQg78nMK2UZ454hAG+OAW+HQPZ6n++TNDUX+L0+uUlLywnoxJKDou51Zm+zTCjrCl0Nq6J9C5hP9vK/Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/postgres-interval": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/postgres-interval/-/postgres-interval-1.2.0.tgz",
+      "integrity": "sha512-9ZhXKM/rw350N1ovuWHbGxnGh/SNJ4cnxHiM0rxE4VN41wsg8P8zWn9hv/buK00RP4WvlOyr/RBDiptyxVbkZQ==",
+      "license": "MIT",
+      "dependencies": {
+        "xtend": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/prebuild-install": {
       "version": "7.1.3",
       "resolved": "https://registry.npmjs.org/prebuild-install/-/prebuild-install-7.1.3.tgz",
@@ -7755,12 +7962,6 @@
       "funding": {
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
-    },
-    "node_modules/process-nextick-args": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
-      "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
-      "license": "MIT"
     },
     "node_modules/promise-inflight": {
       "version": "1.0.1",
@@ -7937,27 +8138,6 @@
       "engines": {
         "node": ">=0.10.0"
       }
-    },
-    "node_modules/readable-stream": {
-      "version": "2.3.7",
-      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
-      "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
-      "license": "MIT",
-      "dependencies": {
-        "core-util-is": "~1.0.0",
-        "inherits": "~2.0.3",
-        "isarray": "~1.0.0",
-        "process-nextick-args": "~2.0.0",
-        "safe-buffer": "~5.1.1",
-        "string_decoder": "~1.1.1",
-        "util-deprecate": "~1.0.1"
-      }
-    },
-    "node_modules/readable-stream/node_modules/safe-buffer": {
-      "version": "5.1.2",
-      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
-      "license": "MIT"
     },
     "node_modules/rechoir": {
       "version": "0.8.0",
@@ -8183,6 +8363,11 @@
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
       "license": "MIT"
+    },
+    "node_modules/seq-queue": {
+      "version": "0.0.5",
+      "resolved": "https://registry.npmjs.org/seq-queue/-/seq-queue-0.0.5.tgz",
+      "integrity": "sha512-hr3Wtp/GZIc/6DAGPDcV4/9WoZhjrkXsi5B/07QgX8tsdc6ilr7BFM6PM6rbdAX1kFSDYeZGLipIZZKyQP0O5Q=="
     },
     "node_modules/serve-favicon": {
       "version": "2.5.1",
@@ -8495,6 +8680,15 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/split2": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/split2/-/split2-4.2.0.tgz",
+      "integrity": "sha512-UcjcJOWknrNkF6PLX83qcHM6KHgVKNkV62Y8a5uYDVv9ydGQVwAHMKqHdJje1VTWpljG0WYpCDhrCdAOYH4TWg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">= 10.x"
+      }
+    },
     "node_modules/sprintf-js": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
@@ -8531,15 +8725,6 @@
       "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-7.1.1.tgz",
       "integrity": "sha512-5m3bsyrjFWE1xf7nz7YXdN4udnVtXK6/Yfgn5qnahL6bCkf2yKt4k3nuTKAtT4r3IG8JNR2ncsIMdZuAzJjHQQ==",
       "license": "MIT"
-    },
-    "node_modules/sqlstring": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/sqlstring/-/sqlstring-2.3.1.tgz",
-      "integrity": "sha512-ooAzh/7dxIG5+uDik1z/Rd1vli0+38izZhGzSa34FwR7IbelPWCCKSNIl8jlL/F7ERvy8CB2jNeM1E9i9mXMAQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.6"
-      }
     },
     "node_modules/ssri": {
       "version": "8.0.1",
@@ -9573,6 +9758,15 @@
       "resolved": "https://registry.npmjs.org/sax/-/sax-1.2.4.tgz",
       "integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw==",
       "license": "ISC"
+    },
+    "node_modules/xtend": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
+      "integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4"
+      }
     },
     "node_modules/y18n": {
       "version": "5.0.8",

--- a/package.json
+++ b/package.json
@@ -31,13 +31,14 @@
     "knex": "^3.1.0",
     "method-override": "^3.0.0",
     "morgan": "^1.10.0",
-    "mysql": "^2.18.1",
+    "mysql2": "^3.11.4",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
     "serve-favicon": "^2.5.1",
     "sqlite3": "^5.1.7",
     "stylus": "^0.64.0",
     "supervisord": "^0.1.0",
+    "pg": "^8.13.1",
     "zod": "^3.23.8"
   },
   "devDependencies": {

--- a/seeds/001_default_admin.cjs
+++ b/seeds/001_default_admin.cjs
@@ -2,9 +2,7 @@
  * @param {import('knex')} knex
  */
 exports.seed = async function seed(knex) {
-  const existingAdmin = await knex('users')
-    .where({ Email: 'admin@nodervisor' })
-    .first();
+  const existingAdmin = await knex('users').where('Email', 'admin@nodervisor').first();
 
   if (!existingAdmin) {
     await knex('users').insert({

--- a/server/index.js
+++ b/server/index.js
@@ -12,7 +12,7 @@ const knexsessions = Knex(config.sessionstore);
 const sessionStore = new ConnectSessionKnexStore({
   knex: knexsessions,
   tablename: 'sessions',
-  createTable: true
+  createTable: false
 });
 
 const context = createServerContext({


### PR DESCRIPTION
## Summary
- replace the deprecated mysql driver with mysql2, add the pg driver, and normalize database client configuration
- split Knex configuration per environment while adding a migration for the sessions table and ensuring seeds are portable
- update documentation, environment examples, and CI to run migrations and seeds against SQLite and MySQL

## Testing
- npm run migrate
- npm run seed
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d57b4eb368832ea34d42b7baae1b54